### PR TITLE
docs: replace ovh-ux by ovh in repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # OVH UI for Bootstrap 3
 
-![githubbanner](https://user-images.githubusercontent.com/3379410/27423240-3f944bc4-5731-11e7-87bb-3ff603aff8a7.png)
-
 A [Bootstrap 3](https://github.com/twbs/bootstrap) theme for the OVH managers, based on [OVH UI](https://github.com/ovh/ovh-ui-kit).
 
 [![npm version](https://badgen.net/npm/v/ovh-ui-kit-bs)](https://www.npmjs.com/package/ovh-ui-kit-bs)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![githubbanner](https://user-images.githubusercontent.com/3379410/27423240-3f944bc4-5731-11e7-87bb-3ff603aff8a7.png)
 
-A [Bootstrap 3](https://github.com/twbs/bootstrap) theme for the OVH managers, based on [OVH UI](https://github.com/ovh-ux/ovh-ui-kit).
+A [Bootstrap 3](https://github.com/twbs/bootstrap) theme for the OVH managers, based on [OVH UI](https://github.com/ovh/ovh-ui-kit).
 
 [![npm version](https://badgen.net/npm/v/ovh-ui-kit-bs)](https://www.npmjs.com/package/ovh-ui-kit-bs)
 
@@ -22,7 +22,7 @@ yarn add ovh-ui-kit-bs
 
 ### Test page
 
-A test page is available [here](https://ovh-ux.github.io/ovh-ui-kit-bs/) for viewing all styles and component of our theme.
+A test page is available [here](https://ovh.github.io/ovh-ui-kit-bs/) for viewing all styles and component of our theme.
 
 ### Integration
 
@@ -46,7 +46,7 @@ A test page is available [here](https://ovh-ux.github.io/ovh-ui-kit-bs/) for vie
 1. Clone and install `ovh-ui-kit-bs`
 
 ```bash
-git clone https://github.com/ovh-ux/ovh-ui-kit-bs.git
+git clone https://github.com/ovh/ovh-ui-kit-bs.git
 cd ovh-ui-kit-bs
 yarn install
 ```
@@ -62,10 +62,10 @@ If you apply modifications on the source files, you'll need to rebuild the proje
 
 ## Related links
 
- * Contribute: [https://github.com/ovh-ux/ovh-ui-kit-bs/blob/master/CONTRIBUTING.md](https://github.com/ovh-ux/ovh-ui-kit-bs/blob/master/.github/CONTRIBUTING.md)
- * Report bugs: [https://github.com/ovh-ux/ovh-ui-kit-bs/issues](https://github.com/ovh-ux/ovh-ui-kit-bs/issues)
- * Get latest version: [https://github.com/ovh-ux/ovh-ui-kit-bs](https://github.com/ovh-ux/ovh-ui-kit-bs)
+ * Contribute: [https://github.com/ovh/ovh-ui-kit-bs/blob/master/CONTRIBUTING.md](https://github.com/ovh/ovh-ui-kit-bs/blob/master/.github/CONTRIBUTING.md)
+ * Report bugs: [https://github.com/ovh/ovh-ui-kit-bs/issues](https://github.com/ovh/ovh-ui-kit-bs/issues)
+ * Get latest version: [https://github.com/ovh/ovh-ui-kit-bs](https://github.com/ovh/ovh-ui-kit-bs)
 
 ## License
 
-See https://github.com/ovh-ux/ovh-ui-kit-bs/blob/master/LICENSE
+See https://github.com/ovh/ovh-ui-kit-bs/blob/master/LICENSE

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "description": "A bootstrap theme for the OVH managers, based on ovh-ui-kit.",
   "license": "BSD-3-Clause",
-  "homepage": "https://ovh-ux.github.io/ovh-ui-kit-bs/",
+  "homepage": "https://ovh.github.io/ovh-ui-kit-bs/",
   "author": "OVH SAS",
   "files": [
     "dist"
@@ -11,11 +11,11 @@
   "main": "./dist/js/bootstrap.js",
   "style": "./dist/css/oui-bs3.css",
   "bugs": {
-    "url": "https://github.com/ovh-ux/ovh-ui-kit-bs/issues"
+    "url": "https://github.com/ovh/ovh-ui-kit-bs/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ovh-ux/ovh-ui-kit-bs.git"
+    "url": "https://github.com/ovh/ovh-ui-kit-bs.git"
   },
   "scripts": {
     "build": "run-s clean dist docs",


### PR DESCRIPTION
## Replace ovh-ux by ovh in repository path

### Description of the Change

#### 📝 Documentation

5a5189b - docs: replace ovh-ux by ovh in repository path
9510000 - docs: remove banner from the README.md file 

ref: MANAGER-4496

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>


