### PR TITLE
build: remove source-map flag when compiling less files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "run-s clean dist docs",
     "clean": "rimraf dist docs/assets",
     "dist": "run-p dist:*",
-    "dist:less": "lessc --remcalc --clean-css --source-map \"src/index.less\" \"dist/css/oui-bs3.css\"",
+    "dist:less": "lessc --remcalc --clean-css \"src/index.less\" \"dist/css/oui-bs3.css\"",
     "dist:fonts": "cpx \"src/fonts/**/*\" \"dist/fonts\"",
     "dist:bootstrap": "cpx \"node_modules/bootstrap/dist/{fonts/**/*,js/bootstrap.*}\" \"dist/\"",
     "docs": "run-p docs:*",


### PR DESCRIPTION
## Remove source-map flag when compiling less files

### Description of the Change

#### 👷 Build

4d87446 - build: remove source-map flag when compiling less files

### Benefits

Sourcemap files are no more versioned into the `docs` folder.

### Possible Drawbacks

None

### Applicable Issues

Closes #94

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>