### PR TITLE
fix(variables): use hover text decoration for hovered links

### DIFF
--- a/docs/less/bootstrap/_variables.less
+++ b/docs/less/bootstrap/_variables.less
@@ -39,7 +39,7 @@
 // Link hover color set via `darken()` function.
 @link-hover-color:      @oui-link-font-color_hover;
 // Link hover decoration.
-@link-hover-decoration: @oui-link-text-decoration;
+@link-hover-decoration: @oui-link-text-decoration_hover;
 
 //== Typography
 //


### PR DESCRIPTION
## use hover text decoration for hovered links


### Description of the Change

use hover text decoration for hovered links instead of non hover links text decoration

